### PR TITLE
contributing-guide update (ToolJet#526)

### DIFF
--- a/docs/docs/contributing-guide/setup/docker.md
+++ b/docs/docs/contributing-guide/setup/docker.md
@@ -10,15 +10,17 @@ Docker compose is the easiest way to setup ToolJet server and client locally.
 Make sure you have the latest version of `docker` and `docker-compose` installed.
 
 [Official docker installation guide](https://docs.docker.com/desktop/)
+<br>
 [Official docker-compose installation guide](https://docs.docker.com/compose/install/)
 
 We recommend:
-  ```bash
-   docker --version
+```bash
+> docker --version
   Docker version 19.03.12, build 48a66213fe
-   docker-compose --version
+  
+> docker-compose --version
   docker-compose version 1.26.2, build eefe0d31
-  ```
+```
 
 ## Setting up
 


### PR DESCRIPTION
resolving issue #526

- Added space and proper distinction between the two commands 
- Added a line break between the two links